### PR TITLE
[CARE-1518] Get rid of `@react-hookz/web` dependency

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.0.0-alpha.9"
+  "version": "5.0.0-alpha.10"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.0.0-alpha.8"
+  "version": "5.0.0-alpha.9"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.0.0-alpha.10"
+  "version": "5.0.0-alpha.11"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16666,7 +16666,7 @@
     },
     "packages/core": {
       "name": "@prezly/theme-kit-core",
-      "version": "5.0.0-alpha.7",
+      "version": "5.0.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "@prezly/uploadcare": "^2.3.4",
@@ -16685,14 +16685,14 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.0.0-alpha.8",
+      "version": "5.0.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^16.0.0",
         "next-seo": "^5.4.0"
       },
       "devDependencies": {
-        "@prezly/theme-kit-core": "^5.0.0-alpha.7",
+        "@prezly/theme-kit-core": "^5.0.0-alpha.9",
         "@sentry/nextjs": "7.50.0"
       },
       "engines": {
@@ -19284,7 +19284,7 @@
     "@prezly/theme-kit-nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@prezly/theme-kit-core": "^5.0.0-alpha.7",
+        "@prezly/theme-kit-core": "^5.0.0-alpha.9",
         "@react-hookz/web": "^16.0.0",
         "@sentry/nextjs": "7.50.0",
         "next-seo": "^5.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3526,29 +3526,6 @@
         "is-plain-object": "^5.0.0"
       }
     },
-    "node_modules/@react-hookz/deep-equal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hookz/deep-equal/-/deep-equal-1.0.3.tgz",
-      "integrity": "sha512-lGZR5l3YRjzeIOHtJhiq96vQKrsq+9lsCyv+0fROMQeSNWtLLzX3R+psHNi6nsoP3XEhspiZ92nsiPmdNo8ztQ=="
-    },
-    "node_modules/@react-hookz/web": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@react-hookz/web/-/web-16.1.0.tgz",
-      "integrity": "sha512-yLa3QIwYHWKI0NkY0yd72599GLnWx6yGESBieGmPF/4k30Fe4M0RP06xHcV9qJWxGQsk3Bn5BnBPb2YH6u12vQ==",
-      "dependencies": {
-        "@react-hookz/deep-equal": "^1.0.3"
-      },
-      "peerDependencies": {
-        "js-cookie": "^3.0.1",
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      },
-      "peerDependenciesMeta": {
-        "js-cookie": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.0.tgz",
@@ -16688,7 +16665,6 @@
       "version": "5.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
-        "@react-hookz/web": "^16.0.0",
         "next-seo": "^5.4.0"
       },
       "devDependencies": {
@@ -19285,7 +19261,6 @@
       "version": "file:packages/nextjs",
       "requires": {
         "@prezly/theme-kit-core": "^5.0.0-alpha.9",
-        "@react-hookz/web": "^16.0.0",
         "@sentry/nextjs": "7.50.0",
         "next-seo": "^5.4.0"
       }
@@ -19326,19 +19301,6 @@
       "integrity": "sha512-G4U0H89YSp/krcIjSSuZDqCZ2NeE4qQkFjY0yf7vkOf0IuRjpTfLb9Jr8uaOYFpql2ln8XINBPSFZWImThcB8g==",
       "requires": {
         "is-plain-object": "^5.0.0"
-      }
-    },
-    "@react-hookz/deep-equal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hookz/deep-equal/-/deep-equal-1.0.3.tgz",
-      "integrity": "sha512-lGZR5l3YRjzeIOHtJhiq96vQKrsq+9lsCyv+0fROMQeSNWtLLzX3R+psHNi6nsoP3XEhspiZ92nsiPmdNo8ztQ=="
-    },
-    "@react-hookz/web": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@react-hookz/web/-/web-16.1.0.tgz",
-      "integrity": "sha512-yLa3QIwYHWKI0NkY0yd72599GLnWx6yGESBieGmPF/4k30Fe4M0RP06xHcV9qJWxGQsk3Bn5BnBPb2YH6u12vQ==",
-      "requires": {
-        "@react-hookz/deep-equal": "^1.0.3"
       }
     },
     "@rollup/plugin-commonjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16662,7 +16662,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.0.0-alpha.10",
+      "version": "5.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
         "next-seo": "^5.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16685,7 +16685,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.0.0-alpha.9",
+      "version": "5.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@react-hookz/web": "^16.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-core",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.9",
   "description": "Data layer and utility library for developing Prezly themes with JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.0.0-alpha.10",
+  "version": "5.0.0-alpha.11",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.0.0-alpha.8",
+  "version": "5.0.0-alpha.9",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -54,7 +54,7 @@
     "next-seo": "^5.4.0"
   },
   "devDependencies": {
-    "@prezly/theme-kit-core": "^5.0.0-alpha.7",
+    "@prezly/theme-kit-core": "^5.0.0-alpha.9",
     "@sentry/nextjs": "7.50.0"
   },
   "publishConfig": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -50,7 +50,6 @@
     "react-dom": "^17.x || ^18.x"
   },
   "dependencies": {
-    "@react-hookz/web": "^16.0.0",
     "next-seo": "^5.4.0"
   },
   "devDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.0.0-alpha.9",
+  "version": "5.0.0-alpha.10",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/src/infinite-loading/lib/index.ts
+++ b/packages/nextjs/src/infinite-loading/lib/index.ts
@@ -1,0 +1,1 @@
+export { useAsync } from './useAsync';

--- a/packages/nextjs/src/infinite-loading/lib/useAsync.ts
+++ b/packages/nextjs/src/infinite-loading/lib/useAsync.ts
@@ -1,0 +1,136 @@
+/**
+ * This code is ported from `@react-hookz/web` package, to avoid importing the whole package in the client bundle.
+ * @see https://github.com/react-hookz/web/blob/master/src/useAsync/index.ts
+ */
+
+import { useMemo, useRef, useState } from 'react';
+
+import { useSyncedRef } from './useSyncedRef';
+
+export type AsyncStatus = 'loading' | 'success' | 'error' | 'not-executed';
+
+export type AsyncState<Result> =
+    | {
+          status: 'not-executed';
+          error: undefined;
+          result: Result;
+      }
+    | {
+          status: 'success';
+          error: undefined;
+          result: Result;
+      }
+    | {
+          status: 'error';
+          error: Error;
+          result: Result;
+      }
+    | {
+          status: AsyncStatus;
+          error: Error | undefined;
+          result: Result;
+      };
+
+export interface UseAsyncActions<Result, Args extends unknown[] = unknown[]> {
+    /**
+     * Reset state to initial.
+     */
+    reset: () => void;
+    /**
+     * Execute the async function manually.
+     */
+    execute: (...args: Args) => Promise<Result>;
+}
+
+export interface UseAsyncMeta<Result, Args extends unknown[] = unknown[]> {
+    /**
+     * Latest promise returned from the async function.
+     */
+    promise: Promise<Result> | undefined;
+    /**
+     * List of arguments applied to the latest async function invocation.
+     */
+    lastArgs: Args | undefined;
+}
+
+export function useAsync<Result, Args extends unknown[] = unknown[]>(
+    asyncFn: (...params: Args) => Promise<Result>,
+    initialValue: Result,
+): [AsyncState<Result>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>];
+export function useAsync<Result, Args extends unknown[] = unknown[]>(
+    asyncFn: (...params: Args) => Promise<Result>,
+    initialValue?: Result,
+): [AsyncState<Result | undefined>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>];
+
+/**
+ * Tracks the result and errors of the provided async function and provides handles to control its execution.
+ *
+ * @param asyncFn Function that returns a promise.
+ * @param initialValue Value that will be set on initialisation before the async function is
+ * executed.
+ */
+export function useAsync<Result, Args extends unknown[] = unknown[]>(
+    asyncFn: (...params: Args) => Promise<Result>,
+    initialValue?: Result,
+): [AsyncState<Result | undefined>, UseAsyncActions<Result, Args>, UseAsyncMeta<Result, Args>] {
+    const [state, setState] = useState<AsyncState<Result | undefined>>({
+        status: 'not-executed',
+        error: undefined,
+        result: initialValue,
+    });
+    const promiseRef = useRef<Promise<Result>>();
+    const argsRef = useRef<Args>();
+
+    const methods = useSyncedRef({
+        execute: (...params: Args) => {
+            argsRef.current = params;
+            const promise = asyncFn(...params);
+            promiseRef.current = promise;
+
+            setState((s) => ({ ...s, status: 'loading' }));
+
+            promise.then(
+                (result) => {
+                    // we dont want to handle result/error of non-latest function
+                    // this approach helps to avoid race conditions
+                    if (promise === promiseRef.current) {
+                        setState((s) => ({ ...s, status: 'success', error: undefined, result }));
+                    }
+                },
+                (error: Error) => {
+                    // we dont want to handle result/error of non-latest function
+                    // this approach helps to avoid race conditions
+                    if (promise === promiseRef.current) {
+                        setState((s) => ({ ...s, status: 'error', error }));
+                    }
+                },
+            );
+
+            return promise;
+        },
+        reset: () => {
+            setState({
+                status: 'not-executed',
+                error: undefined,
+                result: initialValue,
+            });
+            promiseRef.current = undefined;
+            argsRef.current = undefined;
+        },
+    });
+
+    return [
+        state,
+        useMemo(
+            () => ({
+                reset: () => {
+                    methods.current.reset();
+                },
+                execute: (...params: Args) => methods.current.execute(...params),
+            }),
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            [],
+        ),
+        { promise: promiseRef.current, lastArgs: argsRef.current },
+    ];
+}

--- a/packages/nextjs/src/infinite-loading/lib/useSyncedRef.ts
+++ b/packages/nextjs/src/infinite-loading/lib/useSyncedRef.ts
@@ -1,0 +1,27 @@
+/**
+ * This code is ported from `@react-hookz/web` package, to avoid importing the whole package in the client bundle.
+ * @see https://github.com/react-hookz/web/blob/master/src/useSyncedRef/index.ts
+ */
+
+import { useMemo, useRef } from 'react';
+
+/**
+ * Like `useRef`, but it returns immutable ref that contains actual value.
+ *
+ * @param value
+ */
+export function useSyncedRef<T>(value: T): { readonly current: T } {
+    const ref = useRef(value);
+
+    ref.current = value;
+
+    return useMemo(
+        () =>
+            Object.freeze({
+                get current() {
+                    return ref.current;
+                },
+            }),
+        [],
+    );
+}

--- a/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
@@ -1,6 +1,6 @@
-import { useAsync } from '@react-hookz/web/cjs/useAsync/useAsync';
 import { useCallback, useEffect, useState } from 'react';
 
+import { useAsync } from './lib';
 import type { PaginationProps } from './types';
 
 interface Parameters<T> {

--- a/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
@@ -1,4 +1,4 @@
-import { useAsync } from '@react-hookz/web/esm/useAsync/useAsync';
+import { useAsync } from '@react-hookz/web/cjs/useAsync/useAsync';
 import { useCallback, useEffect, useState } from 'react';
 
 import type { PaginationProps } from './types';

--- a/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteLoading.ts
@@ -1,4 +1,4 @@
-import { useAsync } from '@react-hookz/web';
+import { useAsync } from '@react-hookz/web/esm/useAsync/useAsync';
 import { useCallback, useEffect, useState } from 'react';
 
 import type { PaginationProps } from './types';


### PR DESCRIPTION
While most of our themes use this package anyway, it doesn't make sense to bring in the whole package in the Theme Kit just for one hook. This saves about 7.4 Kb Gzipped on apps that don't use `@react-hookz/web`.