### PR TITLE
[CARE-1556] Fix issue with `arr.at is undefined` in safari 14 

### DIFF
--- a/packages/core/src/seo/getAlternateLanguageLinks.ts
+++ b/packages/core/src/seo/getAlternateLanguageLinks.ts
@@ -57,7 +57,7 @@ export function getAlternateLanguageLinks<
             // We try to find fallback from provided translations of current regionIndependentLocaleCode
             // If there is no defined fallback in the list we will use just first translation as a region independent translation
             const fallback =
-                getFallbackLocale(regionIndependentLocaleCode, localesArray) ?? localesArray.at(0);
+                getFallbackLocale(regionIndependentLocaleCode, localesArray) ?? localesArray[0];
 
             if (fallback) {
                 pushLocaleToLinks(fallback, regionIndependentLocaleCode);

--- a/packages/core/src/seo/getAlternateLanguageLinks.ts
+++ b/packages/core/src/seo/getAlternateLanguageLinks.ts
@@ -57,7 +57,9 @@ export function getAlternateLanguageLinks<
             // We try to find fallback from provided translations of current regionIndependentLocaleCode
             // If there is no defined fallback in the list we will use just first translation as a region independent translation
             const fallback =
-                getFallbackLocale(regionIndependentLocaleCode, localesArray) ?? localesArray[0];
+                getFallbackLocale(regionIndependentLocaleCode, localesArray) ??
+                // using simple array index as Array.at() is supported only in Safari 15.4 upwards
+                localesArray[0];
 
             if (fallback) {
                 pushLocaleToLinks(fallback, regionIndependentLocaleCode);


### PR DESCRIPTION
The issue was due to `Array.at()` only being supported in Safari 15.4 and upwards.

Updated to use simple array indexing instead