### PR TITLE
[CARE-1572] Prioritize languages with same neutral code in `getLanguageByShortRegionCode`

### DIFF
--- a/packages/core/src/__mocks__/languages.ts
+++ b/packages/core/src/__mocks__/languages.ts
@@ -1,15 +1,17 @@
 import { Culture, type NewsroomLanguageSettings } from '@prezly/sdk';
 
-/**
- * This data is pulled from The Good Newsroom (with some extra cultures) and reduced to only fields required by tests.
- */
-export const LANGUAGES: Record<
+type MockLanguages = Record<
     string,
     Pick<
         NewsroomLanguageSettings,
         'locale' | 'is_default' | 'public_stories_count' | 'code' | 'company_information'
     >
-> = {
+>;
+
+/**
+ * This data is pulled from The Good Newsroom (with some extra cultures) and reduced to only fields required by tests.
+ */
+export const LANGUAGES: MockLanguages = {
     nl_BE: {
         code: 'nl_BE',
         locale: {
@@ -392,6 +394,91 @@ export const LANGUAGES: Record<
                 '<p>Utilizamos cookies en nuestro sitio web. Nos ayudan a conocerle un poco y saber cómo usa nuestro sitio web, lo que nos sirve para proporcionarle a usted y a los demás una experiencia más valiosa y personalizada.</p>',
             subscribe_disclaimer:
                 '<p>Al confirmar su suscripción, confirma que entiende que se está registrando para recibir contenido y accede a que su información se procese y guarde de manera segura.</p>',
+            seo_settings: {
+                canonical_url: null,
+                default_meta_title: null,
+                default_meta_description: null,
+                meta_title: null,
+                meta_description: null,
+            },
+        },
+    },
+};
+
+export const LANGUAGES_2: MockLanguages = {
+    de_DE: {
+        code: 'de_DE',
+        locale: {
+            code: 'de_DE',
+            locale: 'de_DE',
+            name: 'German (Germany)',
+            native_name: 'Deutsch (Deutschland)',
+            direction: Culture.TextDirection.LTR,
+            language_code: 'de',
+        },
+        is_default: false,
+        public_stories_count: 90,
+        company_information: {
+            name: 'The Good News Room',
+            about: '',
+            about_plaintext: '',
+            email: null,
+            website: null,
+            phone: null,
+            address: null,
+            twitter: null,
+            facebook: null,
+            linkedin: null,
+            pinterest: null,
+            youtube: null,
+            instagram: null,
+            tiktok: null,
+            email_disclaimer: '',
+            cookie_statement: '',
+            subscribe_disclaimer: '',
+            seo_settings: {
+                canonical_url: null,
+                default_meta_title: null,
+                default_meta_description: null,
+                meta_title: null,
+                meta_description: null,
+            },
+        },
+    },
+    en_DE: {
+        code: 'en_DE',
+        locale: {
+            code: 'en_DE',
+            locale: 'en_DE',
+            name: 'English (Germany)',
+            native_name: 'English (Germany)',
+            direction: Culture.TextDirection.LTR,
+            language_code: 'en',
+        },
+        is_default: true,
+        public_stories_count: 75,
+        company_information: {
+            name: 'The Good News Room',
+            about: '<p>Er is veel slecht nieuws in de wereld. Wij wilden een moment nemen om te focussen op de goeie dingen in het leven, want zelfs in de donkerste nacht zijn er sterren. ✨<br />Heb je zelf een leuk, positief verhaal? Vertel het ons! ☺︎</p>',
+            about_plaintext:
+                'Er is veel slecht nieuws in de wereld. Wij wilden een moment nemen om te focussen op de goeie dingen in het leven, want zelfs in de donkerste nacht zijn er sterren. ✨Heb je zelf een leuk, positief verhaal? Vertel het ons! ☺︎',
+            email: 'happy@prezly.com',
+            website: 'https://www.prezly.com/',
+            phone: null,
+            address: null,
+            twitter: 'prezly',
+            facebook: 'PrezlyPR',
+            linkedin: 'https://www.linkedin.com/company/prezly',
+            pinterest: null,
+            youtube: null,
+            instagram: 'prezly.official',
+            tiktok: null,
+            email_disclaimer:
+                '<p>U heeft deze e-mail ontvangen, omdat u een contact van %companyname% bent. Als u deze e-mails niet meer wenst te ontvangen, kunt u zich <a href="%unsubscribe_url%">uitschrijven</a>.</p>',
+            cookie_statement:
+                '<p>We maken gebruik van cookies op onze website. Deze helpen ons om u iets beter te leren kennen en te zien hoe u onze website gebruikt. <br>Dit helpt ons een waardevollere en op maat gemaakte ervaring te bieden voor u en anderen.</p>',
+            subscribe_disclaimer:
+                '<p>Door uw abonnement te bevestigen, bevestigt u dat u begrijpt dat u zich registreert om materiaal te ontvangen en dat uw gegevens veilig worden verwerkt en opgeslagen.</p>',
             seo_settings: {
                 canonical_url: null,
                 default_meta_title: null,

--- a/packages/core/src/intl/languages.test.ts
+++ b/packages/core/src/intl/languages.test.ts
@@ -1,4 +1,4 @@
-import { LANGUAGES } from '../__mocks__/languages';
+import { LANGUAGES, LANGUAGES_2 } from '../__mocks__/languages';
 import { STORY } from '../__mocks__/story';
 
 import {
@@ -137,6 +137,14 @@ describe('getLanguageByShortRegionCode', () => {
 
         expect(getLanguageByShortRegionCode(languages, LocaleObject.fromAnyCode('be'))).toEqual(
             LANGUAGES.fr_BE,
+        );
+    });
+
+    it('returns correct language with different neutral codes but same region codes', () => {
+        const languages = [LANGUAGES_2.en_DE, LANGUAGES_2.de_DE];
+
+        expect(getLanguageByShortRegionCode(languages, LocaleObject.fromAnyCode('de'))).toEqual(
+            LANGUAGES_2.de_DE,
         );
     });
 });


### PR DESCRIPTION
There is a secondary solution to this: #297 

But that being said, I feel like this PR is cleaner and solves the problem in an earlier stage which makes more sense.