### PR TITLE
[CARE-1572] Priotrizing the language with matching **neutral code & short region** over the only **short region**

### DIFF
--- a/packages/core/src/intl/languages.ts
+++ b/packages/core/src/intl/languages.ts
@@ -95,6 +95,17 @@ export function getLanguageByShortRegionCode<
     Language extends Pick<NewsroomLanguageSettings, 'is_default' | 'code' | 'public_stories_count'>,
 >(languages: Language[], locale: LocaleObject): Language | undefined {
     const shortRegionCode = locale.toRegionCode();
+    const neutralLanguageCode = locale.toNeutralLanguageCode();
+
+    const languageWithSameRegionAndNeutralCode = languages.find(({ code }) => {
+        const comparingLocale = LocaleObject.fromAnyCode(code);
+        const hasSameNeutralCode = comparingLocale.toNeutralLanguageCode() === neutralLanguageCode;
+        const hasSameRegionCode = comparingLocale.toRegionCode() === shortRegionCode;
+        return hasSameNeutralCode && hasSameRegionCode;
+    });
+    if (languageWithSameRegionAndNeutralCode) {
+        return languageWithSameRegionAndNeutralCode;
+    }
 
     // Try to look in used cultures first (giving priority to used ones)
     const usedLanguages = getUsedLanguages(languages);

--- a/packages/core/src/intl/languages.ts
+++ b/packages/core/src/intl/languages.ts
@@ -95,17 +95,6 @@ export function getLanguageByShortRegionCode<
     Language extends Pick<NewsroomLanguageSettings, 'is_default' | 'code' | 'public_stories_count'>,
 >(languages: Language[], locale: LocaleObject): Language | undefined {
     const shortRegionCode = locale.toRegionCode();
-    const neutralLanguageCode = locale.toNeutralLanguageCode();
-
-    const languageWithSameRegionAndNeutralCode = languages.find(({ code }) => {
-        const comparingLocale = LocaleObject.fromAnyCode(code);
-        const hasSameNeutralCode = comparingLocale.toNeutralLanguageCode() === neutralLanguageCode;
-        const hasSameRegionCode = comparingLocale.toRegionCode() === shortRegionCode;
-        return hasSameNeutralCode && hasSameRegionCode;
-    });
-    if (languageWithSameRegionAndNeutralCode) {
-        return languageWithSameRegionAndNeutralCode;
-    }
 
     // Try to look in used cultures first (giving priority to used ones)
     const usedLanguages = getUsedLanguages(languages);

--- a/packages/core/src/intl/languages.ts
+++ b/packages/core/src/intl/languages.ts
@@ -227,6 +227,20 @@ export function getLanguageFromLocaleIsoCode<
     // We're excluding the default language, since it shouldn't have a URL slug
     const languagesWithoutDefault = languages.filter(({ is_default }) => !is_default);
 
+    const shortRegionCode = locale.toRegionCode();
+    const neutralLanguageCode = locale.toNeutralLanguageCode();
+
+    const languageWithSameRegionAndNeutralCode = languagesWithoutDefault.find(({ code }) => {
+        const comparingLocale = LocaleObject.fromAnyCode(code);
+        const hasSameNeutralCode = comparingLocale.toNeutralLanguageCode() === neutralLanguageCode;
+        const hasSameRegionCode = comparingLocale.toRegionCode() === shortRegionCode;
+        return hasSameNeutralCode && hasSameRegionCode;
+    });
+
+    if (languageWithSameRegionAndNeutralCode) {
+        return languageWithSameRegionAndNeutralCode;
+    }
+
     const regionMatchedLanguage = getLanguageByShortRegionCode(languagesWithoutDefault, locale);
     if (regionMatchedLanguage) {
         return regionMatchedLanguage;

--- a/packages/nextjs/src/intl/languages.ts
+++ b/packages/nextjs/src/intl/languages.ts
@@ -21,19 +21,6 @@ export function getLanguageFromNextLocaleIsoCode<
     }
 
     const locale = LocaleObject.fromAnyCode(nextLocaleIsoCode);
-    const shortRegionCode = locale.toRegionCode();
-    const neutralLanguageCode = locale.toNeutralLanguageCode();
-
-    const languageWithSameRegionAndNeutralCode = languages.find(({ code }) => {
-        const comparingLocale = LocaleObject.fromAnyCode(code);
-        const hasSameNeutralCode = comparingLocale.toNeutralLanguageCode() === neutralLanguageCode;
-        const hasSameRegionCode = comparingLocale.toRegionCode() === shortRegionCode;
-        return hasSameNeutralCode && hasSameRegionCode;
-    });
-
-    if (languageWithSameRegionAndNeutralCode) {
-        return languageWithSameRegionAndNeutralCode;
-    }
 
     return getLanguageFromLocaleIsoCode(languages, locale);
 }

--- a/packages/nextjs/src/intl/languages.ts
+++ b/packages/nextjs/src/intl/languages.ts
@@ -21,5 +21,19 @@ export function getLanguageFromNextLocaleIsoCode<
     }
 
     const locale = LocaleObject.fromAnyCode(nextLocaleIsoCode);
+    const shortRegionCode = locale.toRegionCode();
+    const neutralLanguageCode = locale.toNeutralLanguageCode();
+
+    const languageWithSameRegionAndNeutralCode = languages.find(({ code }) => {
+        const comparingLocale = LocaleObject.fromAnyCode(code);
+        const hasSameNeutralCode = comparingLocale.toNeutralLanguageCode() === neutralLanguageCode;
+        const hasSameRegionCode = comparingLocale.toRegionCode() === shortRegionCode;
+        return hasSameNeutralCode && hasSameRegionCode;
+    });
+
+    if (languageWithSameRegionAndNeutralCode) {
+        return languageWithSameRegionAndNeutralCode;
+    }
+
     return getLanguageFromLocaleIsoCode(languages, locale);
 }


### PR DESCRIPTION
Fix for #301 

Prioritize language selection based on a matching combination of neutral code and short region over solely relying on a short region. This is what fixes the issue.

At this point, I'm going crazy with these sequences of PRs.