### PR TITLE
[DEV-10857] Add correct `Cache-Control` headers to every page server request, export `withPrezlyConfig` helper

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.1-alpha.1"
+  "version": "5.3.1-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.1-alpha.3"
+  "version": "5.3.1-alpha.4"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.1-alpha.4"
+  "version": "5.3.1-alpha.5"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.1-alpha.2"
+  "version": "5.3.1-alpha.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.1-alpha.0"
+  "version": "5.3.1-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "5.3.0"
+  "version": "5.3.1-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.1-alpha.4",
+      "version": "5.3.1-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.1-alpha.3",
+      "version": "5.3.1-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.1-alpha.2",
+      "version": "5.3.1-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.0",
+      "version": "5.3.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.1-alpha.0",
+      "version": "5.3.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "5.3.1-alpha.1",
+      "version": "5.3.1-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^5.3.0",

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -54,6 +54,25 @@ If you don't have these credentials, you can use one of our [testing newsrooms c
 In a base setup, you don't have to make any changes to your config.
 Depending on your use-case, you might need to make some additions to your base config.
 
+#### `withPrezlyConfig` helper
+
+You can add all of the necessary properties to your Next config with a single helper function.
+It adds the required `i18n` config, `images` config if you're using `next/image` to display images served from Prezly, and recommended security headers.
+Apart from several properties in `i18n` config, all of your existing config properties will be preserved and merged with our custom properties.
+You can control each of the config overrides with optional parameters object.
+
+```js
+const withPrezlyConfig = require('@prezly/theme-kit-nextjs/config')(/* Optional parameters for PrezlyConfig */);
+
+const config ={
+    /* ...your next config... */
+};
+
+module.exports = withPrezlyConfig(config);
+```
+
+You can also add the properties manually if you want even more control over the config.
+
 #### Using next/image to display images served from Prezly
 
 We provide `@prezly/uploadcare-image` package to conveniently display images inside Prezly content, and this is the recommended way to display images in your theme.

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.1-alpha.1",
+  "version": "5.3.1-alpha.2",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.1-alpha.4",
+  "version": "5.3.1-alpha.5",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.1-alpha.3",
+  "version": "5.3.1-alpha.4",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.0",
+  "version": "5.3.1-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.1-alpha.2",
+  "version": "5.3.1-alpha.3",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "5.3.1-alpha.0",
+  "version": "5.3.1-alpha.1",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -7,11 +7,13 @@
   "files": ["build", "README.md"],
   "exports": {
     ".": "./build/index.js",
+    "./config": "./build/config.js",
     "./server": "./build/server.js",
     "./playwright": "./build/playwright/index.js"
   },
   "typesVersions": {
     "*": {
+      "config": ["build/config.d.ts"],
       "server": ["build/server.d.ts"],
       "playwright": ["build/playwright/index.d.ts"]
     }

--- a/packages/nextjs/src/adapter-nextjs/processRequest.ts
+++ b/packages/nextjs/src/adapter-nextjs/processRequest.ts
@@ -21,9 +21,7 @@ export function processRequest<Props>(
     assertServerEnv('processRequest');
     const { locale: nextLocale, query, res } = context;
 
-    console.log({ env: process.env.NODE_ENV, headers: process.env.PREZLY_ADD_RECOMMENDED_HEADERS });
-
-    if (process.env.NODE_ENV === 'production' && process.env.PREZLY_ADD_RECOMMENDED_HEADERS) {
+    if (process.env.NODE_ENV === 'production') {
         // Since Next 13, Cache-Control header set in `next.config.js` is overwritten by Next in production, effectively bypassing any caching systems setup on top of the theme.
         // This is a workaround for that issue. See https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching
         res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');

--- a/packages/nextjs/src/adapter-nextjs/processRequest.ts
+++ b/packages/nextjs/src/adapter-nextjs/processRequest.ts
@@ -21,6 +21,8 @@ export function processRequest<Props>(
     assertServerEnv('processRequest');
     const { locale: nextLocale, query, res } = context;
 
+    console.log({ env: process.env.NODE_ENV, headers: process.env.PREZLY_ADD_RECOMMENDED_HEADERS });
+
     if (process.env.NODE_ENV === 'production' && process.env.PREZLY_ADD_RECOMMENDED_HEADERS) {
         // Since Next 13, Cache-Control header set in `next.config.js` is overwritten by Next in production, effectively bypassing any caching systems setup on top of the theme.
         // This is a workaround for that issue. See https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching

--- a/packages/nextjs/src/adapter-nextjs/processRequest.ts
+++ b/packages/nextjs/src/adapter-nextjs/processRequest.ts
@@ -19,7 +19,11 @@ export function processRequest<Props>(
     canonicalUrl?: string,
 ): GetServerSidePropsResult<Props> {
     assertServerEnv('processRequest');
-    const { locale: nextLocale, query } = context;
+    const { locale: nextLocale, query, res } = context;
+
+    // Since Next 13, Cache-Control header set in `next.config.js` is overwritten by Next in production, effectively bypassing any caching systems setup on top of the theme.
+    // This is a workaround for that issue. See https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
 
     const { localeResolved, ...pageProps } = props;
 

--- a/packages/nextjs/src/adapter-nextjs/processRequest.ts
+++ b/packages/nextjs/src/adapter-nextjs/processRequest.ts
@@ -21,9 +21,11 @@ export function processRequest<Props>(
     assertServerEnv('processRequest');
     const { locale: nextLocale, query, res } = context;
 
-    // Since Next 13, Cache-Control header set in `next.config.js` is overwritten by Next in production, effectively bypassing any caching systems setup on top of the theme.
-    // This is a workaround for that issue. See https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching
-    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+    if (process.env.NODE_ENV === 'production' && process.env.PREZLY_ADD_RECOMMENDED_HEADERS) {
+        // Since Next 13, Cache-Control header set in `next.config.js` is overwritten by Next in production, effectively bypassing any caching systems setup on top of the theme.
+        // This is a workaround for that issue. See https://nextjs.org/docs/pages/building-your-application/deploying/production-checklist#caching
+        res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+    }
 
     const { localeResolved, ...pageProps } = props;
 

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -1,7 +1,7 @@
 import locales from '@prezly/theme-kit-core/localeConfig';
 import type { NextConfig } from 'next';
 
-import { DUMMY_DEFAULT_LOCALE } from '../intl';
+import { DUMMY_DEFAULT_LOCALE } from './intl';
 
 interface PrezlyConfigParams {
     /**

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -32,12 +32,6 @@ export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
 
         return {
             ...config,
-            env: {
-                ...config.env,
-                ...(finalParams.recommendedHeaders && {
-                    PREZLY_ADD_RECOMMENDED_HEADERS: '1',
-                }),
-            },
             ...(finalParams.recommendedHeaders && {
                 async headers() {
                     return [

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -32,6 +32,12 @@ export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
 
         return {
             ...config,
+            env: {
+                ...config.env,
+                ...(finalParams.recommendedHeaders && {
+                    PREZLY_ADD_RECOMMENDED_HEADERS: '1',
+                }),
+            },
             ...(finalParams.recommendedHeaders && {
                 async headers() {
                     return [

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -24,8 +24,7 @@ const DEFAULT_PARAMS: PrezlyConfigParams = {
     recommendedHeaders: true,
 };
 
-// eslint-disable-next-line import/no-default-export
-export default function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
+export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
     const finalParams = { ...DEFAULT_PARAMS, ...params };
 
     return function withPrezlyConfig(config: NextConfig): NextConfig {
@@ -86,4 +85,4 @@ export default function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
             }),
         };
     };
-}
+};

--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -1,0 +1,89 @@
+import locales from '@prezly/theme-kit-core/localeConfig';
+import type { NextConfig } from 'next';
+
+import { DUMMY_DEFAULT_LOCALE } from '../intl';
+
+interface PrezlyConfigParams {
+    /**
+     * Enables Prezly i18n support. Defaults to `true`
+     */
+    i18n: boolean;
+    /**
+     * Enables support for Prezly images in `next/image`. Defaults to `true`
+     */
+    images: boolean;
+    /**
+     * Adds security headers recommended by Prezly. Defaults to `true`
+     */
+    recommendedHeaders: boolean;
+}
+
+const DEFAULT_PARAMS: PrezlyConfigParams = {
+    i18n: true,
+    images: true,
+    recommendedHeaders: true,
+};
+
+// eslint-disable-next-line import/no-default-export
+export default function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
+    const finalParams = { ...DEFAULT_PARAMS, ...params };
+
+    return function withPrezlyConfig(config: NextConfig): NextConfig {
+        const { headers } = config;
+
+        return {
+            ...config,
+            ...(finalParams.recommendedHeaders && {
+                async headers() {
+                    return [
+                        ...(typeof headers === 'function' ? await headers() : []),
+                        {
+                            source: '/(.*)',
+                            locale: false,
+                            headers: [
+                                {
+                                    key: 'Strict-Transport-Security',
+                                    value: 'max-age=63072000; includeSubDomains; preload',
+                                },
+                                {
+                                    key: 'X-XSS-Protection',
+                                    value: '1; mode=block',
+                                },
+                                {
+                                    key: 'X-Frame-Options',
+                                    value: 'SAMEORIGIN',
+                                },
+                                {
+                                    key: 'X-Content-Type-Options',
+                                    value: 'nosniff',
+                                },
+                                {
+                                    key: 'Content-Security-Policy',
+                                    value: 'upgrade-insecure-requests; report-uri https://csp.prezly.net/report;',
+                                },
+                            ],
+                        },
+                    ];
+                },
+            }),
+            images: {
+                ...config.images,
+                domains: [...(config.images?.domains || []), 'cdn.uc.assets.prezly.com'],
+            },
+            ...(finalParams.i18n && {
+                i18n: {
+                    ...config.i18n,
+                    // These are all the locales you want to support in
+                    // your application
+                    locales: [...locales, DUMMY_DEFAULT_LOCALE],
+                    // This is the default locale you want to be used when visiting
+                    // a non-locale prefixed path e.g. `/hello`
+                    // We use Pseudo locale used for localization testing, to reliably determine if we need to fallback to the default newsroom language
+                    defaultLocale: DUMMY_DEFAULT_LOCALE,
+                    // Default locale detection is disabled, since the locales would be determined by Prezly API
+                    localeDetection: false,
+                },
+            }),
+        };
+    };
+}


### PR DESCRIPTION
This fixes issue with Next 13 overriding the `Cache-Control` headers set in `next.config.js`.