### PR TITLE
[CARE-1683] Exclude `main` branch from running E2E tests in themes

### DIFF
--- a/.github/workflows/playwright.shared.yml
+++ b/.github/workflows/playwright.shared.yml
@@ -6,6 +6,11 @@
 
 name: Playwright Tests
 on:
+  push:
+    branches:
+      - '*'
+      # We are explicitly excluding `main` branch from E2E tests: CARE-1683
+      - '!main'
   workflow_call:
     inputs:
       site-name:


### PR DESCRIPTION
[Source](https://stackoverflow.com/a/58142412/6622233)