### PR TITLE
[CARE-1846] Fix sitemap URLs to support any possible value

### DIFF
--- a/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
@@ -6,15 +6,19 @@ import { createPaths } from './createPaths';
 import { SitemapBuilder } from './SitemapBuilder';
 
 function normalizeBaseUrl(baseUrl: string, protocol = 'https') {
-    if (
-        baseUrl === '/' ||
-        baseUrl.startsWith('localhost') ||
-        baseUrl.startsWith(`${protocol}://`)
-    ) {
+    // This regex pattern matches if the `baseUrl`
+    // equals `/`, starts with `localhost`, or starts with `http://` or `https://`.
+    if (/^(\/|localhost|https?:\/\/)/.test(baseUrl)) {
         return baseUrl;
     }
 
-    return `${protocol}://${baseUrl}`;
+    // If it's explicitly defined to be `http` only
+    if (protocol.toLowerCase() === 'http') {
+        return `http://${baseUrl}`;
+    }
+
+    // Prefer https if protocol is `https,http` or `https` or any other unknown value
+    return `https://${baseUrl}`;
 }
 
 export function getSitemapServerSideProps(


### PR DESCRIPTION
It's hard to test it locally, but my guts telling me that `req.headers['x-forwarded-proto']` can be `https,http`