### PR TITLE
[CARE-1893] Fix SEO title/description overrides not working, allow more title customization

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.0.4"
+  "version": "6.0.5-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15993,7 +15993,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.0.4",
+      "version": "6.0.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.0.4",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.0.4",
+  "version": "6.0.5-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
+++ b/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
@@ -49,14 +49,14 @@ export function PageSeo({
     const { asPath } = useRouter();
 
     const pageTitle =
+        title ||
         companyInformation.seo_settings.meta_title ||
         companyInformation.seo_settings.default_meta_title ||
-        title ||
         companyInformation.name;
     const pageDescription =
+        description ||
         companyInformation.seo_settings.meta_description ||
         companyInformation.seo_settings.default_meta_description ||
-        description ||
         companyInformation.about_plaintext;
     const canonicalUrl =
         canonical || getAbsoluteUrl(asPath, site.url, getLinkLocaleSlug(currentLocale));

--- a/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
+++ b/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
@@ -21,7 +21,12 @@ import {
 
 import { getAbsoluteUrl } from './lib';
 
-type Props = NextSeoProps & {
+type Props = Omit<NextSeoProps, 'title'> & {
+    /**
+     * Overrides the title that is used in the `<title>` tag and in the `og:title` meta tag. Defaults to the Site SEO title or Site name.
+     * If a function is provided, it will be called with the Site SEO title as the first argument.
+     */
+    title?: string | ((metaTitle: string) => string);
     imageUrl?: string;
 };
 
@@ -48,16 +53,25 @@ export function PageSeo({
     const currentStory = useCurrentStory();
     const { asPath } = useRouter();
 
-    const pageTitle =
-        title ||
-        companyInformation.seo_settings.meta_title ||
-        companyInformation.seo_settings.default_meta_title ||
-        companyInformation.name;
+    const pageTitle = useMemo(() => {
+        const defaultMetaTitle =
+            companyInformation.seo_settings.meta_title ||
+            companyInformation.seo_settings.default_meta_title ||
+            companyInformation.name;
+
+        if (title && typeof title === 'function') {
+            return title(defaultMetaTitle);
+        }
+
+        return title || defaultMetaTitle;
+    }, [title, companyInformation]);
+
     const pageDescription =
         description ||
         companyInformation.seo_settings.meta_description ||
         companyInformation.seo_settings.default_meta_description ||
         companyInformation.about_plaintext;
+
     const canonicalUrl =
         canonical || getAbsoluteUrl(asPath, site.url, getLinkLocaleSlug(currentLocale));
     const siteName = companyInformation.name;


### PR DESCRIPTION
- The `title` / `description` props logic was broken during the SEO settings project, making the SEO settings title to always override the custom props. This made customizing the title through themes impossible.

- To allow for more control over the title, I added a possibility to pass a function to the `title` prop, so that Themes can construct more complex title while still relying on our SEO settings logic.