### PR TITLE
[CARE-2260] Fix - Provide basePath when generating absolute URLs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.4"
+  "version": "6.4.5-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.5-alpha.0"
+  "version": "6.4.5-alpha.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16066,7 +16066,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.5-alpha.0",
+      "version": "6.4.5-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16066,7 +16066,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.4",
+      "version": "6.4.5-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.4.4",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.5-alpha.0",
+  "version": "6.4.5-alpha.1",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.4",
+  "version": "6.4.5-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
+++ b/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
@@ -51,7 +51,8 @@ export function PageSeo({
     const getTranslationUrl = useGetTranslationUrl();
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const currentStory = useCurrentStory();
-    const { asPath } = useRouter();
+    const { asPath, basePath } = useRouter();
+    const currentPath = `${asPath}${basePath}`;
 
     const pageTitle = useMemo(() => {
         const defaultMetaTitle =
@@ -73,7 +74,7 @@ export function PageSeo({
         companyInformation.about_plaintext;
 
     const canonicalUrl =
-        canonical || getAbsoluteUrl(asPath, site.url, getLinkLocaleSlug(currentLocale));
+        canonical || getAbsoluteUrl(currentPath, site.url, getLinkLocaleSlug(currentLocale));
     const siteName = companyInformation.name;
     const sharingImageUrl = imageUrl || getNewsroomOgImageUrl(site, currentLocale);
 
@@ -136,7 +137,7 @@ export function PageSeo({
                 {
                     rel: 'alternate',
                     type: 'application/rss+xml',
-                    href: getAbsoluteUrl('/feed', site.url),
+                    href: getAbsoluteUrl(`${basePath}/feed`, site.url),
                 },
             ]}
             languageAlternates={alternateLanguageLinks}

--- a/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
+++ b/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx
@@ -52,7 +52,7 @@ export function PageSeo({
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const currentStory = useCurrentStory();
     const { asPath, basePath } = useRouter();
-    const currentPath = `${asPath}${basePath}`;
+    const currentPath = `${basePath}${asPath}`;
 
     const pageTitle = useMemo(() => {
         const defaultMetaTitle =


### PR DESCRIPTION
`basePath` was not provided when generating absolute URLs (canonical and alternate links), so sites that are not running on the root path would have these URLs invalid.