### PR TITLE
[CARE-2307] Support Next.js basePath config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.6-alpha.1"
+  "version": "6.4.6-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.1"
+  "version": "6.4.2-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.6-alpha.0"
+  "version": "6.4.6-alpha.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "access": "public"
   },
   "useWorkspaces": true,
-  "version": "6.4.5"
+  "version": "6.4.6-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16035,7 +16035,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.1",
+      "version": "6.4.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16061,7 +16061,7 @@
     },
     "packages/core": {
       "name": "@prezly/theme-kit-core",
-      "version": "6.4.4",
+      "version": "6.4.6-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@prezly/uploadcare": "^2.3.4",
@@ -16082,10 +16082,10 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.5",
+      "version": "6.4.6-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@prezly/theme-kit-core": "^6.4.4",
+        "@prezly/theme-kit-core": "^6.4.6-alpha.0",
         "next-seo": "^5.4.0"
       },
       "devDependencies": {
@@ -18390,7 +18390,7 @@
     "@prezly/theme-kit-nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@prezly/theme-kit-core": "^6.4.4",
+        "@prezly/theme-kit-core": "^6.4.6-alpha.0",
         "@sentry/nextjs": "7.66.0",
         "next-seo": "^5.4.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16056,7 +16056,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.6-alpha.0",
+      "version": "6.4.6-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.4.6-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16056,7 +16056,7 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "6.4.6-alpha.1",
+      "version": "6.4.6-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@prezly/theme-kit-core": "^6.4.6-alpha.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "next": "^13.1.1",
+        "next": "^13.4.12",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.3.4",
@@ -1786,40 +1786,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
       "cpu": [
         "arm64"
       ],
@@ -1832,9 +1802,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
       "cpu": [
         "x64"
       ],
@@ -1846,40 +1816,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
       "cpu": [
         "arm64"
       ],
@@ -1892,9 +1832,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
       "cpu": [
         "arm64"
       ],
@@ -1907,9 +1847,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
       "cpu": [
         "x64"
       ],
@@ -1922,9 +1862,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
       "cpu": [
         "x64"
       ],
@@ -1937,9 +1877,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
       "cpu": [
         "arm64"
       ],
@@ -1952,9 +1892,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
       "cpu": [
         "ia32"
       ],
@@ -1967,9 +1907,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
       "cpu": [
         "x64"
       ],
@@ -3495,17 +3435,17 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -4797,6 +4737,17 @@
       "dev": true,
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/byte-size": {
@@ -7769,6 +7720,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "node_modules/global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -7882,8 +7838,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -11397,53 +11352,44 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
       "dependencies": {
-        "@next/env": "13.2.4",
-        "@swc/helpers": "0.4.14",
+        "@next/env": "13.4.19",
+        "@swc/helpers": "0.5.1",
+        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=14.6.0"
+        "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "13.2.4",
-        "@next/swc-android-arm64": "13.2.4",
-        "@next/swc-darwin-arm64": "13.2.4",
-        "@next/swc-darwin-x64": "13.2.4",
-        "@next/swc-freebsd-x64": "13.2.4",
-        "@next/swc-linux-arm-gnueabihf": "13.2.4",
-        "@next/swc-linux-arm64-gnu": "13.2.4",
-        "@next/swc-linux-arm64-musl": "13.2.4",
-        "@next/swc-linux-x64-gnu": "13.2.4",
-        "@next/swc-linux-x64-musl": "13.2.4",
-        "@next/swc-win32-arm64-msvc": "13.2.4",
-        "@next/swc-win32-ia32-msvc": "13.2.4",
-        "@next/swc-win32-x64-msvc": "13.2.4"
+        "@next/swc-darwin-arm64": "13.4.19",
+        "@next/swc-darwin-x64": "13.4.19",
+        "@next/swc-linux-arm64-gnu": "13.4.19",
+        "@next/swc-linux-arm64-musl": "13.4.19",
+        "@next/swc-linux-x64-gnu": "13.4.19",
+        "@next/swc-linux-x64-musl": "13.4.19",
+        "@next/swc-win32-arm64-msvc": "13.4.19",
+        "@next/swc-win32-ia32-msvc": "13.4.19",
+        "@next/swc-win32-x64-msvc": "13.4.19"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.4.0",
-        "fibers": ">= 3.1.0",
-        "node-sass": "^6.0.0 || ^7.0.0",
+        "@opentelemetry/api": "^1.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
-          "optional": true
-        },
-        "fibers": {
-          "optional": true
-        },
-        "node-sass": {
           "optional": true
         },
         "sass": {
@@ -14483,6 +14429,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -15728,6 +15682,18 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -16057,6 +16023,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "packages/core": {
@@ -17449,9 +17423,9 @@
       }
     },
     "@next/env": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-      "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+      "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.3.4",
@@ -17478,82 +17452,58 @@
         }
       }
     },
-    "@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-      "optional": true
-    },
-    "@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-      "optional": true
-    },
     "@next/swc-darwin-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-      "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+      "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-      "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+      "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-      "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+      "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-      "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+      "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-      "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+      "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-      "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+      "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-      "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+      "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-      "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+      "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-      "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+      "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -18690,17 +18640,17 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "requires": {
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
@@ -19682,6 +19632,14 @@
       "dev": true,
       "requires": {
         "semver": "^7.0.0"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "byte-size": {
@@ -21943,6 +21901,11 @@
         "is-glob": "^4.0.3"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -22028,8 +21991,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -24706,28 +24668,27 @@
       "dev": true
     },
     "next": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-      "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+      "version": "13.4.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+      "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
       "requires": {
-        "@next/env": "13.2.4",
-        "@next/swc-android-arm-eabi": "13.2.4",
-        "@next/swc-android-arm64": "13.2.4",
-        "@next/swc-darwin-arm64": "13.2.4",
-        "@next/swc-darwin-x64": "13.2.4",
-        "@next/swc-freebsd-x64": "13.2.4",
-        "@next/swc-linux-arm-gnueabihf": "13.2.4",
-        "@next/swc-linux-arm64-gnu": "13.2.4",
-        "@next/swc-linux-arm64-musl": "13.2.4",
-        "@next/swc-linux-x64-gnu": "13.2.4",
-        "@next/swc-linux-x64-musl": "13.2.4",
-        "@next/swc-win32-arm64-msvc": "13.2.4",
-        "@next/swc-win32-ia32-msvc": "13.2.4",
-        "@next/swc-win32-x64-msvc": "13.2.4",
-        "@swc/helpers": "0.4.14",
+        "@next/env": "13.4.19",
+        "@next/swc-darwin-arm64": "13.4.19",
+        "@next/swc-darwin-x64": "13.4.19",
+        "@next/swc-linux-arm64-gnu": "13.4.19",
+        "@next/swc-linux-arm64-musl": "13.4.19",
+        "@next/swc-linux-x64-gnu": "13.4.19",
+        "@next/swc-linux-x64-musl": "13.4.19",
+        "@next/swc-win32-arm64-msvc": "13.4.19",
+        "@next/swc-win32-ia32-msvc": "13.4.19",
+        "@next/swc-win32-x64-msvc": "13.4.19",
+        "@swc/helpers": "0.5.1",
+        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0",
+        "zod": "3.21.4"
       }
     },
     "next-seo": {
@@ -26990,6 +26951,11 @@
         "internal-slot": "^1.0.4"
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -27906,6 +27872,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -28167,6 +28142,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release:publish:preview": "lerna publish prerelease --dist-tag preview"
   },
   "dependencies": {
-    "next": "^13.1.1",
+    "next": "^13.4.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-core",
-  "version": "6.4.4",
+  "version": "6.4.6-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with JavaScript",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -73,6 +73,10 @@ module.exports = withPrezlyConfig(config);
 
 You can also add the properties manually if you want even more control over the config.
 
+#### Usage with `basePath` setting
+
+When using `basePath` setting in your next.config.js, wrapping your config with `withPrezlyConfig` will automatically populate `NEXT_PUBLIC_BASE_PATH` env variable, which will be respected by Theme Kit helpers and hooks (like `useInfiniteStoriesLoading`). We also export `getResolvedPath` helper that can be used to resolve paths with respect to your `basePath` setting.
+
 #### Using next/image to display images served from Prezly
 
 We provide `@prezly/uploadcare-image` package to conveniently display images inside Prezly content, and this is the recommended way to display images in your theme.

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.5",
+  "version": "6.4.6-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -59,7 +59,7 @@
     }
   },
   "dependencies": {
-    "@prezly/theme-kit-core": "^6.4.4",
+    "@prezly/theme-kit-core": "^6.4.6-alpha.0",
     "next-seo": "^5.4.0"
   },
   "devDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.1",
+  "version": "6.4.2-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.6-alpha.0",
+  "version": "6.4.6-alpha.1",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "6.4.6-alpha.1",
+  "version": "6.4.6-alpha.2",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
@@ -46,7 +46,10 @@ export function getSitemapServerSideProps(
         const categories = await api.getCategories();
 
         const paths = createPaths(stories, categories);
-        const sitemapBuilder = new SitemapBuilder(baseUrl, options.basePath);
+        const sitemapBuilder = new SitemapBuilder(
+            baseUrl,
+            options.basePath || process.env.NEXT_PUBLIC_BASE_PATH,
+        );
 
         sitemapBuilder.addUrl('/');
         paths.forEach((path) => sitemapBuilder.addUrl(path));

--- a/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
+++ b/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
@@ -2,7 +2,8 @@ import { getResolvedPath } from '../../../utils';
 
 // Returns absolute URL based on the path and without any query parameters
 export function getAbsoluteUrl(path: string, origin: string, localeCode?: string | false): string {
-    const finalPath = localeCode ? `/${localeCode}${path || ''}` : `${path || '/'}`;
+    const prefixedPath = path && !path.startsWith('/') ? `/${path}` : path;
+    const finalPath = localeCode ? `/${localeCode}${prefixedPath || ''}` : `${prefixedPath || '/'}`;
 
     const url = new URL(getResolvedPath(finalPath), origin);
     url.search = '';

--- a/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
+++ b/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
@@ -1,6 +1,11 @@
+import { getResolvedPath } from '../../../utils';
+
 // Returns absolute URL based on the path and without any query parameters
 export function getAbsoluteUrl(path: string, origin: string, localeCode?: string | false): string {
-    const url = new URL(`${localeCode ? `/${localeCode}` : ''}${path || '/'}`, origin);
+    const url = new URL(
+        `${localeCode ? `/${localeCode}` : ''}${getResolvedPath(path || '/')}`,
+        origin,
+    );
     url.search = '';
 
     return url.toString();

--- a/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
+++ b/packages/nextjs/src/components-nextjs/PageSeo/lib/getAbsoluteUrl.ts
@@ -2,10 +2,9 @@ import { getResolvedPath } from '../../../utils';
 
 // Returns absolute URL based on the path and without any query parameters
 export function getAbsoluteUrl(path: string, origin: string, localeCode?: string | false): string {
-    const url = new URL(
-        `${localeCode ? `/${localeCode}` : ''}${getResolvedPath(path || '/')}`,
-        origin,
-    );
+    const finalPath = localeCode ? `/${localeCode}${path || ''}` : `${path || '/'}`;
+
+    const url = new URL(getResolvedPath(finalPath), origin);
     url.search = '';
 
     return url.toString();

--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -28,7 +28,7 @@ export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
     const finalParams = { ...DEFAULT_PARAMS, ...params };
 
     return function withPrezlyConfig(config: NextConfig): NextConfig {
-        const { headers } = config;
+        const { headers, basePath } = config;
 
         return {
             ...config,
@@ -81,6 +81,12 @@ export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
                     defaultLocale: DUMMY_DEFAULT_LOCALE,
                     // Default locale detection is disabled, since the locales would be determined by Prezly API
                     localeDetection: false,
+                },
+            }),
+            ...(basePath && {
+                env: {
+                    ...config.env,
+                    NEXT_PUBLIC_BASE_PATH: basePath,
                 },
             }),
         };

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -4,3 +4,4 @@ export * from './intl';
 export * from './newsroom-context';
 export * from './sentry';
 export * from './types';
+export * from './utils';

--- a/packages/nextjs/src/infinite-loading/useInfiniteGalleriesLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteGalleriesLoading.ts
@@ -1,5 +1,7 @@
 import type { NewsroomGallery } from '@prezly/sdk';
 
+import { getResolvedPath } from '../utils';
+
 import type { PaginationProps } from './types';
 import { useInfiniteLoading } from './useInfiniteLoading';
 
@@ -7,7 +9,7 @@ async function fetchGalleries(
     page: number,
     pageSize: number,
 ): Promise<{ galleries: NewsroomGallery[] }> {
-    const result = await fetch('/api/fetch-galleries', {
+    const result = await fetch(getResolvedPath('/api/fetch-galleries'), {
         method: 'POST',
         headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/nextjs/src/infinite-loading/useInfiniteStoriesLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteStoriesLoading.ts
@@ -3,6 +3,7 @@ import type { LocaleObject } from '@prezly/theme-kit-core';
 import { useEffect } from 'react';
 
 import { useCurrentLocale } from '../newsroom-context';
+import { getResolvedPath } from '../utils';
 
 import type { PaginationProps } from './types';
 import { useInfiniteLoading } from './useInfiniteLoading';
@@ -17,7 +18,7 @@ async function fetchStories<T extends Story = Story>(
     pinning?: boolean,
     filterQuery?: Object,
 ): Promise<{ stories: T[]; storiesTotal: number }> {
-    const result = await fetch('/api/fetch-stories', {
+    const result = await fetch(getResolvedPath('/api/fetch-stories'), {
         method: 'POST',
         headers: {
             // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/nextjs/src/intl/locale.ts
+++ b/packages/nextjs/src/intl/locale.ts
@@ -24,7 +24,8 @@ export function getRedirectToCanonicalLocale(
         : shortestLocaleCode;
 
     if (shortestLocaleSlug !== nextLocaleIsoCode) {
-        const prefixedPath = redirectPath.startsWith('/') ? redirectPath : `/${redirectPath}`;
+        const prefixedPath =
+            redirectPath && !redirectPath.startsWith('/') ? `/${redirectPath}` : redirectPath;
         const finalPath = shortestLocaleSlug
             ? `/${shortestLocaleSlug}${prefixedPath}`
             : prefixedPath;

--- a/packages/nextjs/src/intl/locale.ts
+++ b/packages/nextjs/src/intl/locale.ts
@@ -24,14 +24,15 @@ export function getRedirectToCanonicalLocale(
         : shortestLocaleCode;
 
     if (shortestLocaleSlug !== nextLocaleIsoCode) {
-        const prefixedPath = shortestLocaleSlug
-            ? `/${shortestLocaleSlug}${redirectPath}`
-            : redirectPath;
+        const prefixedPath = redirectPath.startsWith('/') ? redirectPath : `/${redirectPath}`;
+        const finalPath = shortestLocaleSlug
+            ? `/${shortestLocaleSlug}${prefixedPath}`
+            : prefixedPath;
 
         const urlQuery = query ? `?${stringify(query)}` : '';
 
         return {
-            destination: `${getResolvedPath(prefixedPath)}${urlQuery}`,
+            destination: `${getResolvedPath(finalPath)}${urlQuery}`,
             permanent: false,
         };
     }

--- a/packages/nextjs/src/intl/locale.ts
+++ b/packages/nextjs/src/intl/locale.ts
@@ -24,14 +24,14 @@ export function getRedirectToCanonicalLocale(
         : shortestLocaleCode;
 
     if (shortestLocaleSlug !== nextLocaleIsoCode) {
-        const prefixedPath = getResolvedPath(redirectPath);
+        const prefixedPath = shortestLocaleSlug
+            ? `/${shortestLocaleSlug}${redirectPath}`
+            : redirectPath;
 
         const urlQuery = query ? `?${stringify(query)}` : '';
 
         return {
-            destination: shortestLocaleSlug
-                ? `/${shortestLocaleSlug}${prefixedPath}${urlQuery}`
-                : `${prefixedPath}${urlQuery}`,
+            destination: `${getResolvedPath(prefixedPath)}${urlQuery}`,
             permanent: false,
         };
     }

--- a/packages/nextjs/src/intl/locale.ts
+++ b/packages/nextjs/src/intl/locale.ts
@@ -3,6 +3,8 @@ import type { Redirect } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import { stringify } from 'querystring';
 
+import { getResolvedPath } from '../utils';
+
 // We use pseudo locale used for localization testing, to reliably determine if we need to fallback to the default newsroom language
 export const DUMMY_DEFAULT_LOCALE = 'qps-ploc';
 
@@ -22,8 +24,7 @@ export function getRedirectToCanonicalLocale(
         : shortestLocaleCode;
 
     if (shortestLocaleSlug !== nextLocaleIsoCode) {
-        const prefixedPath =
-            redirectPath && !redirectPath.startsWith('/') ? `/${redirectPath}` : redirectPath;
+        const prefixedPath = getResolvedPath(redirectPath);
 
         const urlQuery = query ? `?${stringify(query)}` : '';
 

--- a/packages/nextjs/src/utils.ts
+++ b/packages/nextjs/src/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Adds the base path to the given path, if provided via the env variable.
+ *
+ */
+export function getResolvedPath(path?: undefined): string | undefined;
+export function getResolvedPath(path: string): string;
+export function getResolvedPath(path?: string) {
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+    const prefixedPath = path && !path.startsWith('/') ? `/${path}` : path;
+    if (!basePath) {
+        return prefixedPath;
+    }
+
+    if (prefixedPath === '/' || !prefixedPath) {
+        return basePath;
+    }
+
+    return `${basePath}${path}`;
+}

--- a/packages/nextjs/src/utils.ts
+++ b/packages/nextjs/src/utils.ts
@@ -15,5 +15,5 @@ export function getResolvedPath(path?: string) {
         return basePath;
     }
 
-    return `${basePath}${path}`;
+    return `${basePath}${prefixedPath}`;
 }


### PR DESCRIPTION
This change adds proper support for Next `basePath` setting, and also exports `getResolvedPath` helper to properly resolve URLs with respect to `basePath` configuration.