### PR TITLE
[DEV-11804] Deduplicate supported locales list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21271,6 +21271,7 @@
       "version": "6.6.0",
       "license": "MIT",
       "dependencies": {
+        "@prezly/theme-kit-intl": "^6.6.0",
         "@prezly/uploadcare": "^2.3.4",
         "isomorphic-fetch": "^3.0.0",
         "parse-data-url": "^4.0.1"
@@ -25896,6 +25897,7 @@
     "@prezly/theme-kit-core": {
       "version": "file:packages/core",
       "requires": {
+        "@prezly/theme-kit-intl": "^6.6.0",
         "@prezly/uploadcare": "^2.3.4",
         "@types/isomorphic-fetch": "0.0.37",
         "@types/parse-data-url": "3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "@prezly/sdk": "^16.1"
   },
   "dependencies": {
+    "@prezly/theme-kit-intl": "^6.6.0",
     "@prezly/uploadcare": "^2.3.4",
     "isomorphic-fetch": "^3.0.0",
     "parse-data-url": "^4.0.1"

--- a/packages/core/src/intl/locale.ts
+++ b/packages/core/src/intl/locale.ts
@@ -1,3 +1,5 @@
+import { isLocaleSupported } from '@prezly/theme-kit-intl';
+
 import type { LocaleObject } from './localeObject';
 
 export const DEFAULT_LOCALE = 'en';
@@ -7,76 +9,19 @@ export type RegionCode = string;
 export type LocaleCode = string;
 
 /**
- * This a list of locales that Prezly has translations for. Each code represents a language file in the `@prezly/theme-kit-intl` package.
- * See https://github.com/prezly/themes-intl-messages for more info.
- */
-const SUPPORTED_LOCALES: LocaleCode[] = [
-    'af',
-    'ar',
-    'az',
-    'be',
-    'bg',
-    'cs',
-    'da',
-    'de',
-    'el',
-    'en',
-    'es',
-    'et',
-    'fi',
-    'fil',
-    'fr',
-    'ga',
-    'he',
-    'hi',
-    'hr',
-    'hu',
-    'id',
-    'it',
-    'ja',
-    'kk',
-    'ko',
-    'lt',
-    'lv',
-    'mt',
-    'nl',
-    'no',
-    'pl',
-    'pt-BR',
-    'pt',
-    'ro',
-    'ru',
-    'sk',
-    'sl',
-    'sr',
-    'sv',
-    'sw',
-    'th',
-    'tr',
-    'uk',
-    'ur',
-    'uz',
-    'vi',
-    'zh-CN',
-    'zh-TW',
-];
-
-/**
  * Use this function to determine which translations file you should load from `@prezly/theme-kit-intl` package.
  * See https://github.com/prezly/theme-nextjs-bea/blob/main/utils/lang.ts for a usage example.
  */
 export function getSupportedLocaleIsoCode(locale: LocaleObject): string {
     const localeIsoCode = locale.toHyphenCode();
 
-    const isSupportedLocale =
-        localeIsoCode.length >= 2 && SUPPORTED_LOCALES.includes(localeIsoCode);
+    const isSupportedLocale = localeIsoCode.length >= 2 && isLocaleSupported(localeIsoCode);
     if (isSupportedLocale) {
         return localeIsoCode;
     }
 
     const language = locale.toNeutralLanguageCode();
-    const isSupportedLanguage = SUPPORTED_LOCALES.includes(language);
-    if (isSupportedLanguage) {
+    if (isLocaleSupported(language)) {
         return language;
     }
 


### PR DESCRIPTION
It can already be known from the `intl` package. No need to dupe it (and have desync issues).