### PR TITLE
[DEV-11988] Provide a separate entry point for Sentry configs

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -9,6 +9,7 @@
     ".": "./build/index.js",
     "./config": "./build/config.js",
     "./server": "./build/server.js",
+    "./sentry": "./build/sentry/index.js",
     "./playwright": "./build/playwright/index.js"
   },
   "typesVersions": {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -2,6 +2,5 @@ export * from './components-nextjs';
 export * from './infinite-loading';
 export * from './intl';
 export * from './newsroom-context';
-export * from './sentry';
 export * from './types';
 export * from './utils';


### PR DESCRIPTION
As importing it via the main entry point in Next.js 13 server environment makes the build fail

> ✓ Linting and checking validity of types
>   Collecting page data  ...TypeError: (0 , o.createContext) is not a function