### PR TITLE
[CARE-3106] Make story pinning enabled by default

### DIFF
--- a/packages/core/src/data-fetching/api/PrezlyApi.ts
+++ b/packages/core/src/data-fetching/api/PrezlyApi.ts
@@ -33,6 +33,9 @@ interface GetStoriesOptions<Include extends keyof Story.ExtraFields = never> {
     page?: number;
     pageSize?: number;
     order?: `${SortOrder.Direction}`;
+    /**
+     * @deprecated Story Pinning will always be enabled in the next major release.
+     */
     pinning?: boolean;
     include?: Include[];
     localeCode?: string;

--- a/packages/core/src/data-fetching/api/PrezlyApi.ts
+++ b/packages/core/src/data-fetching/api/PrezlyApi.ts
@@ -114,7 +114,7 @@ export class PrezlyApi {
      */
     async getAllStories({
         order = DEFAULT_SORT_ORDER,
-        pinning = false,
+        pinning = true,
     }: Pick<GetStoriesOptions, 'order' | 'pinning'> = {}) {
         const sortOrder = getChronologicalSortOrder(order, pinning);
         const newsroom = await this.getNewsroom();
@@ -143,7 +143,7 @@ export class PrezlyApi {
         page = undefined,
         pageSize = DEFAULT_PAGE_SIZE,
         order = DEFAULT_SORT_ORDER,
-        pinning = false,
+        pinning = true,
         include,
         localeCode,
         withHighlightedStory,

--- a/packages/core/src/data-fetching/api/queries.ts
+++ b/packages/core/src/data-fetching/api/queries.ts
@@ -49,7 +49,7 @@ export function getStoriesQuery(
     return query;
 }
 
-export function getChronologicalSortOrder(direction: `${SortOrder.Direction}`, pinning = false) {
+export function getChronologicalSortOrder(direction: `${SortOrder.Direction}`, pinning = true) {
     const pinnedFirst = SortOrder.desc('is_pinned');
     const chronological =
         direction === SortOrder.Direction.ASC

--- a/packages/nextjs/src/adapter-nextjs/page-props/home.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/home.ts
@@ -28,6 +28,9 @@ interface Options<Include extends keyof Story.ExtraFields> {
      */
     withHighlightedStory?: boolean;
     pageSize?: number;
+    /**
+     * @deprecated Story Pinning will always be enabled in the next major release.
+     */
     pinning?: boolean;
     filterQuery?: Object;
 }

--- a/packages/nextjs/src/adapter-nextjs/page-props/home.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/home.ts
@@ -39,7 +39,7 @@ export function getHomepageServerSideProps<
     const {
         pageSize = DEFAULT_PAGE_SIZE,
         extraStoryFields,
-        pinning = false,
+        pinning = true,
         withHighlightedStory = false,
         filterQuery,
     } = options || {};
@@ -94,7 +94,7 @@ export function getHomepageStaticProps<
     customProps: CustomProps | PropsFunction<CustomProps, GetStaticPropsContext>,
     options: Options<Include> = {},
 ) {
-    const { pageSize = DEFAULT_PAGE_SIZE, extraStoryFields = [], pinning = false } = options;
+    const { pageSize = DEFAULT_PAGE_SIZE, extraStoryFields = [], pinning = true } = options;
 
     return async function getStaticProps(
         context: GetStaticPropsContext,

--- a/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
@@ -22,7 +22,14 @@ function normalizeBaseUrl(baseUrl: string, protocol = 'https') {
 }
 
 export function getSitemapServerSideProps(
-    options: { additionalPaths?: string[]; basePath?: string; pinning?: boolean } = {},
+    options: {
+        additionalPaths?: string[];
+        basePath?: string;
+        /**
+         * @deprecated Story Pinning will always be enabled in the next major release.
+         */
+        pinning?: boolean;
+    } = {},
 ) {
     return async function getServerSideProps(ctx: NextPageContext) {
         const { res, req } = ctx;

--- a/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/sitemap/getServerSideProps.ts
@@ -41,7 +41,7 @@ export function getSitemapServerSideProps(
 
         const api = getNextPrezlyApi(req);
         const stories = await api.getAllStories({
-            pinning: options.pinning ?? false,
+            pinning: options.pinning ?? true,
         });
         const categories = await api.getCategories();
 

--- a/packages/nextjs/src/adapter-nextjs/page-props/story.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/story.ts
@@ -87,7 +87,7 @@ export function getStoryPageStaticProps<CustomProps extends Record<string, any>>
 export async function getStoryPageStaticPaths(options: { pinning?: boolean } = {}) {
     const api = getNextPrezlyApi();
     const stories = await api.getAllStories({
-        pinning: options.pinning ?? false,
+        pinning: options.pinning ?? true,
     });
 
     const paths = stories.map(({ slug }) => ({ params: { slug } }));

--- a/packages/nextjs/src/adapter-nextjs/page-props/story.ts
+++ b/packages/nextjs/src/adapter-nextjs/page-props/story.ts
@@ -84,7 +84,14 @@ export function getStoryPageStaticProps<CustomProps extends Record<string, any>>
     };
 }
 
-export async function getStoryPageStaticPaths(options: { pinning?: boolean } = {}) {
+export async function getStoryPageStaticPaths(
+    options: {
+        /**
+         * @deprecated Story Pinning will always be enabled in the next major release.
+         */
+        pinning?: boolean;
+    } = {},
+) {
     const api = getNextPrezlyApi();
     const stories = await api.getAllStories({
         pinning: options.pinning ?? true,

--- a/packages/nextjs/src/infinite-loading/useInfiniteStoriesLoading.ts
+++ b/packages/nextjs/src/infinite-loading/useInfiniteStoriesLoading.ts
@@ -15,6 +15,9 @@ async function fetchStories<T extends Story = Story>(
     category?: Category,
     locale?: LocaleObject,
     include?: (keyof Story.ExtraFields)[],
+    /**
+     * @deprecated Story Pinning will always be enabled in the next major release.
+     */
     pinning?: boolean,
     filterQuery?: Object,
 ): Promise<{ stories: T[]; storiesTotal: number }> {
@@ -56,6 +59,9 @@ export function useInfiniteStoriesLoading<T extends Story = Story>(
     pagination: PaginationProps,
     category?: Category,
     include?: (keyof Story.ExtraFields)[],
+    /**
+     * @deprecated Story Pinning will always be enabled in the next major release.
+     */
     pinning?: boolean,
     filterQuery?: Object,
 ) {


### PR DESCRIPTION
We agreed that fragmenting theme functionality for story pinning was not a good call.

I propose enabling it by default, marking it as deprecated, and removing the option completely with the next major release. Since this property only controls the order of the stories returned, there are no breaking changes or critical changes to functionality.