### PR TITLE
[CARE-3749] Fix - Missing `robots` metatag on homepage

### DIFF
--- a/packages/nextjs/src/adapters/metadata/lib/utils/mergePageMetadata.ts
+++ b/packages/nextjs/src/adapters/metadata/lib/utils/mergePageMetadata.ts
@@ -15,7 +15,7 @@ function merge(a: Metadata, b: Metadata): Metadata {
         return omitUndefined(a);
     }
 
-    return {
+    return omitUndefined({
         ...omitUndefined(a),
         ...omitUndefined(b),
         robots: mergeRobots(a.robots, b.robots),
@@ -36,7 +36,7 @@ function merge(a: Metadata, b: Metadata): Metadata {
             ...omitUndefined(a.other ?? {}),
             ...omitUndefined(b.other ?? {}),
         },
-    };
+    });
 }
 
 function mergeRobots(a: Metadata['robots'], b: Metadata['robots']): Metadata['robots'] {


### PR DESCRIPTION
The empty `robots: {}` property was overriding the meaningful one defined in the root layout, as Next.js doesn't use deep-merge strategy for metadata props.