### PR TITLE
[CARE-4368] Display UTC offset when formatting time

### DIFF
--- a/packages/intl/src/formatting/datetime/lib.ts
+++ b/packages/intl/src/formatting/datetime/lib.ts
@@ -21,7 +21,7 @@ export const getTimeFormat = withCache(
             hour: 'numeric',
             minute: 'numeric',
             timeZone,
-            timeZoneName: 'shortGeneric',
+            timeZoneName: 'longOffset',
             ...options,
         }),
 );

--- a/packages/react/src/intl/BaseFormattedTime.tsx
+++ b/packages/react/src/intl/BaseFormattedTime.tsx
@@ -14,7 +14,7 @@ export function BaseFormattedTime({
 
     return (
         <time {...attributes} dateTime={dateTime.toISOString()}>
-            {formatTime(dateTime, { locale, timezone })}
+            {formatTime(dateTime, { locale, timezone }).replace('GMT', 'UTC')}
         </time>
     );
 }


### PR DESCRIPTION
`FormattedTime` will now return the full GMT offset and GMT will be replaced by UTC, so the result will be something like this `08:00 AM UTC+01:00`