### PR TITLE
[CARE-4849] Fix - `verification` metadata property being overwritten

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "9.3.1",
+  "version": "9.3.2-alpha.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31885,10 +31885,10 @@
     },
     "packages/core": {
       "name": "@prezly/theme-kit-core",
-      "version": "9.3.1",
+      "version": "9.3.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@prezly/theme-kit-intl": "^9.3.1",
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
         "@prezly/uploadcare": "^2.3.4",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.2",
@@ -31908,7 +31908,7 @@
     },
     "packages/intl": {
       "name": "@prezly/theme-kit-intl",
-      "version": "9.3.1",
+      "version": "9.3.2-alpha.0",
       "license": "GNU GPL v3",
       "dependencies": {
         "@technically/is-not-undefined": "^1.0.0"
@@ -33318,12 +33318,12 @@
     },
     "packages/nextjs": {
       "name": "@prezly/theme-kit-nextjs",
-      "version": "9.3.1",
+      "version": "9.3.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@prezly/theme-kit-core": "^9.3.1",
-        "@prezly/theme-kit-intl": "^9.3.1",
-        "@prezly/theme-kit-react": "^9.3.1",
+        "@prezly/theme-kit-core": "^9.3.2-alpha.0",
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
+        "@prezly/theme-kit-react": "^9.3.2-alpha.0",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.2",
         "json-stable-stringify": "^1.1.1",
@@ -33352,10 +33352,10 @@
     },
     "packages/react": {
       "name": "@prezly/theme-kit-react",
-      "version": "9.3.1",
+      "version": "9.3.2-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@prezly/theme-kit-intl": "^9.3.1"
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0"
       },
       "engines": {
         "node": ">= 16.x",
@@ -33368,7 +33368,7 @@
     },
     "packages/ui": {
       "name": "@prezly/theme-kit-ui",
-      "version": "9.3.1",
+      "version": "9.3.2-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
@@ -36930,7 +36930,7 @@
     "@prezly/theme-kit-core": {
       "version": "file:packages/core",
       "requires": {
-        "@prezly/theme-kit-intl": "^9.3.1",
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
         "@prezly/uploadcare": "^2.3.4",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.2",
@@ -38064,9 +38064,9 @@
     "@prezly/theme-kit-nextjs": {
       "version": "file:packages/nextjs",
       "requires": {
-        "@prezly/theme-kit-core": "^9.3.1",
-        "@prezly/theme-kit-intl": "^9.3.1",
-        "@prezly/theme-kit-react": "^9.3.1",
+        "@prezly/theme-kit-core": "^9.3.2-alpha.0",
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
+        "@prezly/theme-kit-react": "^9.3.2-alpha.0",
         "@sentry/nextjs": "7.111.0",
         "@technically/is-not-undefined": "^1.0.0",
         "@technically/omit-undefined": "^1.0.2",
@@ -38078,7 +38078,7 @@
     "@prezly/theme-kit-react": {
       "version": "file:packages/react",
       "requires": {
-        "@prezly/theme-kit-intl": "^9.3.1"
+        "@prezly/theme-kit-intl": "^9.3.2-alpha.0"
       }
     },
     "@prezly/theme-kit-ui": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-core",
-  "version": "9.3.1",
+  "version": "9.3.2-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with JavaScript",
   "main": "build/index.mjs",
   "types": "build/index.d.ts",
@@ -32,7 +32,7 @@
     "@prezly/sdk": "20.3.0"
   },
   "dependencies": {
-    "@prezly/theme-kit-intl": "^9.3.1",
+    "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
     "@prezly/uploadcare": "^2.3.4",
     "@technically/is-not-undefined": "^1.0.0",
     "@technically/omit-undefined": "^1.0.2",

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/theme-kit-intl",
-    "version": "9.3.1",
+    "version": "9.3.2-alpha.0",
     "description": "Translations for Prezly themes",
     "type": "module",
     "main": "build/index.mjs",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-nextjs",
-  "version": "9.3.1",
+  "version": "9.3.2-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "type": "module",
   "main": "build/index.mjs",
@@ -86,9 +86,9 @@
     }
   },
   "dependencies": {
-    "@prezly/theme-kit-core": "^9.3.1",
-    "@prezly/theme-kit-intl": "^9.3.1",
-    "@prezly/theme-kit-react": "^9.3.1",
+    "@prezly/theme-kit-core": "^9.3.2-alpha.0",
+    "@prezly/theme-kit-intl": "^9.3.2-alpha.0",
+    "@prezly/theme-kit-react": "^9.3.2-alpha.0",
     "@technically/is-not-undefined": "^1.0.0",
     "@technically/omit-undefined": "^1.0.2",
     "json-stable-stringify": "^1.1.1",

--- a/packages/nextjs/src/adapters/metadata/lib/utils/mergePageMetadata.ts
+++ b/packages/nextjs/src/adapters/metadata/lib/utils/mergePageMetadata.ts
@@ -28,10 +28,7 @@ function merge(a: Metadata, b: Metadata): Metadata {
             ...omitUndefined(a.twitter ?? {}),
             ...omitUndefined(b.twitter ?? {}),
         },
-        verification: {
-            ...omitUndefined(a.verification ?? {}),
-            ...omitUndefined(b.verification ?? {}),
-        },
+        verification: mergeVerification(a.verification, b.verification),
         other: {
             ...omitUndefined(a.other ?? {}),
             ...omitUndefined(b.other ?? {}),
@@ -40,6 +37,20 @@ function merge(a: Metadata, b: Metadata): Metadata {
 }
 
 function mergeRobots(a: Metadata['robots'], b: Metadata['robots']): Metadata['robots'] {
+    if (a && typeof a === 'object' && b && typeof b === 'object') {
+        return {
+            ...omitUndefined(a),
+            ...omitUndefined(b),
+        };
+    }
+
+    return b || a;
+}
+
+function mergeVerification(
+    a: Metadata['verification'],
+    b: Metadata['verification'],
+): Metadata['verification'] {
     if (a && typeof a === 'object' && b && typeof b === 'object') {
         return {
             ...omitUndefined(a),

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-react",
-  "version": "9.3.1",
+  "version": "9.3.2-alpha.0",
   "description": "Data layer and utility library for developing Prezly themes with NextJS",
   "type": "module",
   "main": "build/index.mjs",
@@ -49,7 +49,7 @@
     "react-dom": "^18.x"
   },
   "dependencies": {
-    "@prezly/theme-kit-intl": "^9.3.1"
+    "@prezly/theme-kit-intl": "^9.3.2-alpha.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prezly/theme-kit-ui",
-  "version": "9.3.1",
+  "version": "9.3.2-alpha.0",
   "description": "UI components for Prezly themes",
   "keywords": ["prezly", "themes", "ui"],
   "author": {


### PR DESCRIPTION
The problem was the merging function using empty object as a default for `undefined` property.

In this case, if you don't provide the `verification` property when calling `generatePageMetadata` function both sides default to `undefined`, producing `verification: {}` result, which does not get omitted by `omitUndefined` helper. Next.js then takes this value and overrides the `verification` property provided from `generateRootMetadata`.

With this fix, all the pages will correctly inherit the `verification` property, unless it's explicitly overwritten.