### PR TITLE
[CARE-4999] Feature - Update CSP header to allow iframing in the app

### DIFF
--- a/packages/nextjs/src/config.ts
+++ b/packages/nextjs/src/config.ts
@@ -58,7 +58,7 @@ export = function PrezlyConfig(params?: Partial<PrezlyConfigParams>) {
                                 },
                                 {
                                     key: 'Content-Security-Policy',
-                                    value: 'upgrade-insecure-requests; report-uri https://csp.prezly.net/report;',
+                                    value: "upgrade-insecure-requests; report-uri https://csp.prezly.net/report; frame-ancestors 'self' https://rock.prezly.com https://rock.*.prezly.net http://rock.prezly.test",
                                 },
                             ],
                         },


### PR DESCRIPTION
This is the same change as in https://github.com/prezly/theme-kit-js/pull/682 but for the older version 7 (still used in Lena, Greta and Marcel themes).