### PR TITLE
[CARE-6365] Fix - Add secondary base url for assets that Uploadcare recommends

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,5 @@
 export const ASSETS_CDN_URL = 'https://cdn.uc.assets.prezly.com';
+export const ASSETS_SECONDARY_CDN_URL = 'https://ucarecdn.com';
 export const DEFAULT_PAGE_SIZE = 12;
 export const DEFAULT_GALLERY_PAGE_SIZE = 6;
 export const OG_IMAGE_API_URL = 'https://og.prezly.com/api/og';

--- a/packages/core/src/galleries.ts
+++ b/packages/core/src/galleries.ts
@@ -1,6 +1,6 @@
 import type { NewsroomGallery, UploadedImage } from '@prezly/sdk';
 
-import { ASSETS_CDN_URL } from './constants';
+import { ASSETS_SECONDARY_CDN_URL } from './constants';
 
 export function isEmpty(
     gallery: Pick<NewsroomGallery, 'images_number' | 'videos_number'>,
@@ -36,5 +36,5 @@ export function getArchiveDownloadUrl(
     // Uploadcare doesn't like slashes in filenames even in encoded form.
     const filename = encodeURIComponent(title.replace(/\//g, '_'));
 
-    return `${ASSETS_CDN_URL}/${uuid}/archive/zip/${filename}.zip`;
+    return `${ASSETS_SECONDARY_CDN_URL}/${uuid}/archive/zip/${filename}.zip`;
 }


### PR DESCRIPTION
Followup on https://github.com/prezly/theme-nextjs-bea/pull/1192