### PR TITLE
[DEV-13725] Fix - Reduce transactions sample rate to 0.5%

### DIFF
--- a/packages/nextjs/src/sentry/common.ts
+++ b/packages/nextjs/src/sentry/common.ts
@@ -48,7 +48,7 @@ export function getCommonClientOptions(
     return {
         dsn,
         // Adjust this value in production, or use tracesSampler for greater control
-        tracesSampleRate: 0.02,
+        tracesSampleRate: 0.005,
         // ...
         // Note: if you want to override the automatic release value, do not set a
         // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
This is the same fix but for the `7.x` version.