### PR TITLE
Feature - Allow multiple categories when searching stories

### DIFF
--- a/packages/core/src/content-delivery/ContentDelivery.ts
+++ b/packages/core/src/content-delivery/ContentDelivery.ts
@@ -257,7 +257,9 @@ export function createClient(
                 offset: offset > 0 ? offset + highlighted : offset,
                 search,
                 query: mergeQueries(query, {
-                    [`category.id`]: categories?.length ? { $all: categories.map(({ id }) => id) } : undefined,
+                    [`category.id`]: categories?.length
+                        ? { $all: categories.map(({ id }) => id) }
+                        : undefined,
                     [`newsroom.uuid`]: { $in: [newsroomUuid] },
                     [`locale`]: localeCode ? { $in: [localeCode] } : undefined,
                     [`status`]: { $in: [Story.Status.PUBLISHED] },

--- a/packages/core/src/content-delivery/ContentDelivery.ts
+++ b/packages/core/src/content-delivery/ContentDelivery.ts
@@ -21,7 +21,7 @@ export interface Options {
 export namespace stories {
     export interface SearchParams {
         search?: string;
-        category?: Pick<Category, 'id'>;
+        categories?: Pick<Category, 'id'>[];
         tags?: string[];
         locale?: Pick<Culture, 'code'> | Culture.Code;
         limit: number;
@@ -38,7 +38,7 @@ export namespace stories {
 export namespace allStories {
     export interface SearchParams {
         search?: string;
-        category?: Pick<Category, 'id'>;
+        categories?: Pick<Category, 'id'>[];
         locale?: Pick<Culture, 'code'>;
     }
 
@@ -241,7 +241,7 @@ export function createClient(
                 query,
                 offset = 0,
                 limit,
-                category,
+                categories,
                 locale,
                 highlighted = 0,
                 tags,
@@ -257,7 +257,7 @@ export function createClient(
                 offset: offset > 0 ? offset + highlighted : offset,
                 search,
                 query: mergeQueries(query, {
-                    [`category.id`]: category ? { $any: [category.id] } : undefined,
+                    [`category.id`]: categories?.length ? { $all: categories.map(({ id }) => id) } : undefined,
                     [`newsroom.uuid`]: { $in: [newsroomUuid] },
                     [`locale`]: localeCode ? { $in: [localeCode] } : undefined,
                     [`status`]: { $in: [Story.Status.PUBLISHED] },

--- a/packages/intl/src/locales/pickSuportedLocale.ts
+++ b/packages/intl/src/locales/pickSuportedLocale.ts
@@ -25,7 +25,6 @@ export function pickSupportedLocale(locale: Locale | Locale.AnyCode): Locale.Iso
         return 'zh-CN';
     }
 
-    // eslint-disable-next-line no-console
     console.warn(
         `Unsupported locale provided: "${typeof locale === 'string' ? locale : isoCode}".`,
     );

--- a/packages/nextjs/src/adapters/prezly/cache/redis.ts
+++ b/packages/nextjs/src/adapters/prezly/cache/redis.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import type { ContentDelivery } from '@prezly/theme-kit-core';
 import stableStringify from 'json-stable-stringify';
 import { createClient, type RedisClientOptions } from 'redis';


### PR DESCRIPTION
We need to be able to search stories based on multiple categories for the BNP Paribas custom theme, so I've changed the `category` parameter to an array of `categories`.